### PR TITLE
fixing binaryvar issue

### DIFF
--- a/Iso8583/FieldDescriptor.go
+++ b/Iso8583/FieldDescriptor.go
@@ -172,7 +172,7 @@ func (fd *FieldDescriptor) Pack(fieldNumber int, value string) ([]byte,error) {
 	lenOfLenInd := fd.lengthFormatter.LengthOfLengthIndicator()
 	lengthOfField := fd.formatter.GetPackedLength(len(value))
 	field := make([]byte,lenOfLenInd + lengthOfField)
-	fd.lengthFormatter.Pack(field,len(value),0)
+	fd.lengthFormatter.Pack(field, lengthOfField,0)
 	fieldData,_ := fd.formatter.GetBytes(value)
 	copy(field[lenOfLenInd:],fieldData)
 


### PR DESCRIPTION
The issue was: It could not pack correctly for binaryHex Variable.
In the field descriptor file, packing of binary hex value format's length calculation was off. For the binary hex, the length is supposed to be 1/2 length. However, it was using the un-modified length, and causing the problem.